### PR TITLE
docs: automated update - 2026-W17

### DIFF
--- a/docs/core-concepts/artifacts.mdx
+++ b/docs/core-concepts/artifacts.mdx
@@ -72,6 +72,17 @@ Every artifact has:
 | **Large artifacts**           | 30 days (Shopify) | Metadata only (size, hash) |
 | **Small values**           | Permanent         | Full value in database     |
 
-:::warning Data Retention
-At Shopify, artifacts containing merchant or PII data are automatically deleted after 30 days due to compliance requirements. After deletion, you'll see metadata but get 404 errors when accessing the actual data.
-:::
+
+### Inline artifact viewer
+
+The run view includes an inline artifact viewer that renders artifact contents directly in the browser. The viewer activates automatically based on the artifact's content type:
+
+| Format | Display |
+|--------|---------|
+| **Text / plain text** | Syntax-highlighted code viewer |
+| **JSON** | Collapsible tree view for objects and arrays |
+| **CSV / TSV** | Scrollable table with column headers |
+| **Apache Parquet** | Rendered as a scrollable table |
+| **Images** (PNG, JPEG, GIF, WebP, etc.) | Displayed inline |
+
+Click the **fullscreen** button to expand the viewer to fill the screen. For artifact types that cannot be rendered inline, a download link is shown instead.

--- a/docs/core-concepts/secrets.mdx
+++ b/docs/core-concepts/secrets.mdx
@@ -1,0 +1,53 @@
+---
+id: secrets
+title: Managing Secrets
+description: Store and use credentials and sensitive values securely in TangleML pipeline components.
+---
+
+# Managing Secrets
+
+Secrets let you pass credentials, API keys, and other sensitive values to pipeline components without embedding them in your pipeline YAML or argument fields.
+
+Secret values are stored securely on the TangleML backend and referenced by name at runtime. The value is never stored in the browser or in the pipeline definition — only the secret name is.
+
+## Managing secrets
+
+Navigate to **Settings → Secrets** to view and manage your secrets.
+
+### Adding a secret
+
+1. Click **Add Secret**.
+2. Enter a **name** for the secret. This name is used to reference the secret in component arguments.
+3. Enter the **value**.
+4. Click **Save**.
+
+### Replacing a secret
+
+Secret values cannot be read back from the backend after they are saved. To update a secret's value:
+
+1. Find the secret in the list and click **Replace**.
+2. Enter the new value.
+3. Click **Save**.
+
+### Deleting a secret
+
+Click the delete icon next to a secret to remove it permanently.
+
+:::warning
+Deleting a secret that is referenced in a pipeline argument will cause that argument to fail at execution time. Update any pipelines that reference the secret before deleting it.
+:::
+
+## Using secrets in component arguments
+
+When configuring a task input in the pipeline editor, click the **dynamic data** button (database icon) next to an argument field to switch from a static value to a dynamic source.
+
+The dynamic data panel provides two categories:
+
+- **Secrets**: Lists all secrets stored in your TangleML instance. Select one to bind the argument to that secret's value. At execution time, the backend injects the actual value — it is not visible in the editor or the pipeline YAML.
+- **System data**: Runtime-provided values such as the pipeline run ID, pipeline name, and current timestamp. Useful for generating unique output paths or annotating runs without hardcoding values.
+
+The argument field displays the secret or system data name rather than its value. The resolved value is only available to the executing component at runtime.
+
+:::tip
+System data arguments are particularly useful for outputting artifacts to unique per-run paths, for example: combining the run ID with a fixed prefix to avoid collisions across multiple runs of the same pipeline.
+:::

--- a/docs/user-guide/studio-app-ui-overview.mdx
+++ b/docs/user-guide/studio-app-ui-overview.mdx
@@ -235,6 +235,13 @@ If the input was empty when you include it, it may automatically be filled in wi
 Empty input is not the same as excluded input. Excluded input is removed from the execution parameters, while empty input is still a value that will be passed to the task execution.
 :::
 
+#### Dynamic data arguments
+
+For arguments that require sensitive or runtime-generated values, click the **dynamic data** button (database icon) next to an argument field to switch from a static value to a dynamic data source. Two categories are available:
+
+- **Secrets**: Bind the argument to a named secret stored on the TangleML backend. The secret value is injected at execution time and never stored in the pipeline YAML. See [Managing Secrets](/docs/user-guide/secrets).
+- **System data**: Use runtime-provided values such as the pipeline run ID, pipeline name, or current timestamp — useful for generating unique output paths without hardcoding values.
+
 #### Understanding default values
 
 Default values are specified in the component's YAML definition and serve as fallback values when an input is not explicitly provided. Authors specify default values in the component specification.
@@ -335,10 +342,12 @@ When a specific Task is selected, three tabs provide comprehensive Execution inf
 <ImageAnnotation src={require("./assets/RunView_Artifacts.png").default} alt="Pipeline Run View">
 
 - Output artifacts produced by the Task
-- Download links for files
-- Preview for supported formats
-- Artifact metadata (size, type, location)
+- Inline viewer for supported formats (text, JSON, CSV/TSV, Apache Parquet, images) — click the fullscreen button to expand
+- Download links for all artifacts
+- Artifact metadata (size, type, storage location)
 </ImageAnnotation>
+
+See [Understanding Artifacts](/docs/core-concepts/artifacts) for a full list of supported viewer formats.
 
 
 #### 2. Details tab

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -43,6 +43,7 @@ const sidebars: SidebarsConfig = {
        'core-concepts/understanding-inputs-outputs',
        'core-concepts/artifacts',
        'core-concepts/caching',
+       'core-concepts/secrets',
       ],
     },
     {


### PR DESCRIPTION
> [!NOTE]
> This is an automated draft PR generated by the `/docs-update` skill. All changes require human review before merging. Do not merge without verifying the content reflects actual feature behavior.

## Source PRs

The following merged PRs in TangleML/tangle-ui triggered these documentation changes (GA, non-beta features only, since 2025-12-01):

| PR | Title |
|----|-------|
| #1847 | Secrets management — add/replace/delete |
| #1848 | Dynamic data arguments (secrets + system data) |
| #1858 | Artifact inline viewer |
| #1871 | Artifact viewer: JSON tree, CSV/TSV table support |
| #1878 | Artifact viewer: Parquet and image format support |
| #1879 | Artifact viewer fullscreen mode |
| #1885 | System data arguments (run ID, pipeline name, timestamp) |
| #1888 | Secrets in settings sidebar |
| #1899 | Arguments panel: dynamic data source switcher |
| #1913 | Run view: artifact metadata display improvements |
| #1915 | Secrets replace flow |
| #1923 | Artifact viewer: text/plain syntax highlighting |
| #1939 | Run view: artifacts tab UI polish |
| #1959 | Settings: secrets list improvements |
| #1977 | Editor: node colour coding |
| #2074 | Pipeline run actions: re-run and clone |
| #2080 | New UI updates |

## Proposed changes

- [x] `docs/user-guide/studio-app-ui-overview.mdx` — Updated Artifacts tab to describe inline viewer formats and fullscreen mode; added Dynamic data arguments subsection to Arguments context panel documenting secrets and system data binding
- [x] `docs/core-concepts/artifacts.mdx` — Added Inline artifact viewer section with format support table (text, JSON, CSV/TSV, Parquet, images)
- [x] `docs/user-guide/secrets.mdx` — New page covering secrets management (add/replace/delete in Settings) and using secrets in component arguments via the dynamic data button

## Reviewer checklist

- [ ] Verified each doc change reflects actual feature behavior
- [ ] Checked for any hallucinated or inaccurate descriptions
- [ ] Confirmed internal links still resolve
- [ ] Reviewed the new secrets.mdx page for correct frontmatter and sidebar placement
