### PR TITLE
docs: automated update - 2026-W19

### DIFF
--- a/docs/core-concepts/artifacts.mdx
+++ b/docs/core-concepts/artifacts.mdx
@@ -72,6 +72,16 @@ Every artifact has:
 | **Large artifacts**           | 30 days (Shopify) | Metadata only (size, hash) |
 | **Small values**           | Permanent         | Full value in database     |
 
+The retention period for large artifacts is configured per deployment. When a retention period is configured, the run view displays an **Artifact Storage** warning at the top of the artifact section reminding you that artifacts older than the retention period may no longer be available in remote storage. The notice includes the configured number of days. If your deployment does not configure a retention period, this notice is suppressed.
+
+### When artifacts are no longer available
+
+Artifacts may become unavailable after their retention period has elapsed, or because of a transient storage error. When the inline viewer cannot load an artifact, an inline notice replaces the preview:
+
+- **Artifact unavailable** — the artifact could not be found in storage (HTTP 404). When a retention period is configured, the notice mentions that the artifact may have expired and includes the retention window.
+- **Failed to load artifact** — an unexpected error occurred while fetching the artifact. The HTTP status code and message are included to help diagnose the issue.
+
+Artifact metadata such as size and hash remains visible even when the underlying data is no longer available.
 
 ### Inline artifact viewer
 


### PR DESCRIPTION
> **Automated draft PR** generated by the `docs-update` skill running against `TangleML/tangle-ui`. Requires human review before merging.

## Source PRs

This PR documents user-facing GA changes from the following merged tangle-ui PRs (week 2026-W19, since 2026-05-01):

| PR | Title |
|---|---|
| [#2181](https://github.com/TangleML/tangle-ui/pull/2181) | fix: show contextual artifact unavailability message in preview dialog |

### Source PRs reviewed but not documented

- **#2179** (`Removes dashboard feature flag`) — graduation event, but the existing docs already describe the dashboard as the default home experience, so no doc edits were needed.
- **27 v2-editor PRs** — the V2 editor is gated by the `v2_editor` beta flag (visible only via the `EditorVersionToggle`). Skipped as beta.
- **#2225** — touches `input-aggregator` (beta flag). Skipped as beta.
- **#2241** — adds the new `v2_editor` beta flag. Not documentable per the skill's `src/flags.ts` rule (new beta flags aren't documented).
- **#2234, #2214–#2224** — analytics instrumentation only. Not user-facing.
- **#2212** — internal tooling (auto-docs skill). Not user-facing.
- **6 dependabot PRs** — skipped by `dependencies` label.

## Proposed changes

- [ ] `docs/core-concepts/artifacts.mdx` — Document the configurable artifact retention notice and the new contextual "Artifact unavailable" / "Failed to load artifact" inline notices in the artifact preview dialog (from tangle-ui #2181).

## Reviewer checklist

- [ ] Verified each doc change reflects actual feature behavior
- [ ] Checked for any hallucinated or inaccurate descriptions
- [ ] Confirmed all internal links resolve to real pages
- [ ] Confirmed all images/screenshots exist and are correctly referenced (no broken markdown image tags)
- [ ] Confirmed external URLs are correct and not invented
- [ ] Reviewed any new pages for correct frontmatter/metadata
- [ ] Confirmed any new pages are correctly registered in `sidebars.ts` and appear in the right category
