### PR TITLE
docs: automated update - 2026-W20

### DIFF
--- a/docs/core-concepts/artifacts.mdx
+++ b/docs/core-concepts/artifacts.mdx
@@ -96,3 +96,26 @@ The run view includes an inline artifact viewer that renders artifact contents d
 | **Images** (PNG, JPEG, GIF, WebP, etc.) | Displayed inline |
 
 Click the **fullscreen** button to expand the viewer to fill the screen. For artifact types that cannot be rendered inline, a download link is shown instead.
+
+#### Tabular viewer (CSV, TSV, Parquet)
+
+Tabular artifacts share a common viewer with paging and sticky headers:
+
+- **Initial load**: the first **100 rows** are rendered. The footer shows _"Showing first 100 rows"_.
+- **Load more**: click **Load more** to append another 100 rows. The viewer continues paging up to a **1,000-row preview limit**, after which the footer changes to _"Showing first 1000 rows (preview limit reached)"_.
+- **Load all**: click **Load all** to jump straight to the preview limit without paging.
+- **Sticky column headers**: headers remain visible while you scroll the table vertically. The table also scrolls horizontally when columns overflow the viewport.
+- **Column types**: when the artifact's schema is available (such as for Parquet files), each column header shows the column type below the name. Nullable columns are marked with a trailing `?` (for example `int64?`).
+
+Use the standalone artifact preview page (below) when you need to share a view of an artifact or browse it on its own dedicated page — the tabular viewer there behaves the same way but uses the full window height.
+
+### Standalone artifact preview page
+
+Every artifact has a dedicated, shareable preview page at `/artifact/<artifact-id>`. The page renders the same inline viewer as the run view but fills the browser window, which is useful for inspecting large tables or sharing a specific artifact with a collaborator.
+
+There are two ways to open the page from the run view:
+
+- **Cmd/Ctrl + click the fullscreen button** in the artifact visualizer dialog. The standalone page opens in a new browser tab.
+- **Click the Share button** in the artifact visualizer header. The full preview URL is copied to your clipboard and a "Link copied to clipboard" toast confirms the copy. Paste the link to share it with another user, or open it later.
+
+The preview URL accepts optional `type` and `name` query parameters so the page can pick the right viewer and display label without round-tripping to the run view. Anyone with access to the same TangleML backend can open the link; if the artifact has aged out of remote storage, the page shows the same **Artifact unavailable** notice described above.

--- a/docs/user-guide/studio-app-ui-overview.mdx
+++ b/docs/user-guide/studio-app-ui-overview.mdx
@@ -409,12 +409,14 @@ When a specific Task is selected, three tabs provide comprehensive execution inf
 <ImageAnnotation src={require("./assets/RunView_Artifacts.png").default} alt="Pipeline Run View">
 
 - Output artifacts produced by the Task
-- Inline viewer for supported formats (text, JSON, CSV/TSV, Apache Parquet, images) — click the fullscreen button to expand
+- Inline viewer for supported formats (text, JSON, CSV/TSV, Apache Parquet, images) — click the fullscreen button to expand, or **Cmd/Ctrl + click** the fullscreen button to open the artifact on its own dedicated page in a new tab
+- **Share** button in the viewer header copies the artifact's preview URL to the clipboard so you can share or bookmark a direct link to the artifact
+- Tabular artifacts (CSV, TSV, Parquet) page in batches of 100 rows up to a 1,000-row preview limit; column headers stay sticky while scrolling, and Parquet columns show their type (with `?` marking nullable columns)
 - Download links for all artifacts
 - Artifact metadata (size, type, storage location)
 </ImageAnnotation>
 
-See [Understanding Artifacts](/docs/core-concepts/artifacts) for a full list of supported viewer formats.
+See [Understanding Artifacts](/docs/core-concepts/artifacts) for a full list of supported viewer formats and details on the standalone artifact preview page.
 
 #### 2. Details tab
 


### PR DESCRIPTION
## Automated documentation update for 2026-W20

This is an automated draft PR produced by the `/docs-update` skill from merged PRs in `TangleML/tangle-ui` between **2026-05-08** and **2026-05-15**. **Please review carefully before marking ready — content may contain inaccuracies or hallucinations.**

### Source PRs

| PR | Title | Feature Areas | Status |
| --- | --- | --- | --- |
| #2253 | feat: artifact preview page and sharable artifact links | pipeline-execution | Documented |
| #2252 | fix: Parquet Schema | pipeline-execution | Documented |
| #2250 | fix: Table Visualizer Pagination | pipeline-execution | Documented |
| #2247 | fix: Table Scrolling | pipeline-execution | Documented |

All four PRs touch shared artifact-visualizer components (`src/components/shared/ReactFlow/FlowCanvas/TaskNode/TaskOverview/IOSection/IOCell/ArtifactVisualizer/`) and apply to all users of the run view.

### PRs reviewed but not documented

- **#2270 (`chore: v2 - set editorv2 beta flag to default true`)** — only changes the V2 editor flag's `default` from `false` to `true`. Per the docs-update spec, a default flip while the flag remains `category: "beta"` is not documentable.
- Many V2-only PRs were merged this week (annotation editor revamp, debug panel polish, analytics instrumentation, task details tabs, etc.). The V2 editor's flag is still `category: "beta"` in `src/flags.ts`, so these were treated as in-development and not surfaced to public docs. If V2 is intended to be documented now, graduate the flag and re-run.
- All dependency / `chore(deps)` PRs were filtered as routine.

### Proposed doc changes

- [ ] `docs/core-concepts/artifacts.mdx` — Add a **Tabular viewer** subsection covering the new 100-row paging, 1,000-row preview limit, sticky headers, horizontal scrolling, and Parquet column types (`?` for nullable). Add a new **Standalone artifact preview page** section explaining the `/artifact/<id>` route and the two ways to open it (Cmd/Ctrl + click fullscreen, Share button).
- [ ] `docs/user-guide/studio-app-ui-overview.mdx` — Update the **Artifacts tab** bullet list with the Cmd/Ctrl + click fullscreen behaviour, the new **Share** button, and the tabular paging/sticky-header/column-type details. Update the cross-reference text to mention the standalone preview page.

### Reviewer checklist

- [ ] Verified each doc change reflects actual feature behaviour
- [ ] Checked for any hallucinated or inaccurate descriptions
- [ ] Confirmed all internal links resolve to real pages
- [ ] Confirmed all images/screenshots exist and are correctly referenced (no broken markdown image tags)
- [ ] Confirmed external URLs are correct and not invented
- [ ] Reviewed any new pages for correct frontmatter/metadata
- [ ] Confirmed any new pages are correctly registered in `sidebars.ts` and appear in the right category

_(This run did not add new pages, so no `sidebars.ts` change is needed.)_
