### PR TITLE
docs: automated update - 2026-W21

### DIFF
--- a/docs/user-guide/studio-app-ui-overview.mdx
+++ b/docs/user-guide/studio-app-ui-overview.mdx
@@ -67,6 +67,7 @@ The runs list includes a filter bar with the following controls:
 - **Annotation filters**: Add key/value annotation predicates to filter runs by custom metadata attached at submission time.
 - **Active filter chips**: Active filters appear as removable chips below the filter controls. Click **Clear all** to reset.
 - **Run status**: View the current status of each run (**Running**, **Succeeded**, **Failed**, **Cancelled**).
+- **Run origin**: A small icon at the end of each row indicates where the run was submitted from — a window icon for the Tangle web app, a bot icon for programmatic submissions (CLI or AI), and a question-mark icon when the origin is unknown. Hover the icon for a tooltip describing the source.
 - **Quick access**: Click on any run to view detailed execution information.
 
 ### Components
@@ -397,6 +398,7 @@ When viewing the overall run:
 - Total duration
 - Input parameters used
 - Overall pipeline outputs
+- **Run origin**: An icon next to the **Run Info** heading shows where this run was submitted from — the Tangle web app, a programmatic source (CLI or AI), or an unknown source. Hover the icon for a tooltip describing the origin.
 
 Output nodes in the graph display their artifact values inline when the run has completed.
 


### PR DESCRIPTION
## Automated documentation update — 2026-W21

This is an **automated draft PR** generated by the weekly `/docs-update` skill in `TangleML/tangle-ui`. It must be reviewed by a human before merging.

## Source PRs

Merged PRs from the past week that were screened for user-facing changes:

| PR | Title | Status |
| --- | --- | --- |
| [#2304](https://github.com/TangleML/tangle-ui/pull/2304) | feat: Run Origin Icons | Document |
| [#2303](https://github.com/TangleML/tangle-ui/pull/2303) | chore(deps): bump tailwindcss | Not user-facing |
| [#2302](https://github.com/TangleML/tangle-ui/pull/2302) | Add cooldown to dependabot | Not user-facing |
| [#2300](https://github.com/TangleML/tangle-ui/pull/2300) | chore: rm npm | Not user-facing |
| [#2298](https://github.com/TangleML/tangle-ui/pull/2298) | chore(deps): bump @tanstack/react-router | Not user-facing |
| [#2293](https://github.com/TangleML/tangle-ui/pull/2293) | chore(deps-dev): npm-minor-patch | Not user-facing |
| [#2285](https://github.com/TangleML/tangle-ui/pull/2285) | chore(deps): bump ws | Not user-facing |
| [#2284](https://github.com/TangleML/tangle-ui/pull/2284) | chore(deps): npm-minor-patch | Not user-facing |
| [#2280](https://github.com/TangleML/tangle-ui/pull/2280) | chore(deps): bump react-day-picker | Not user-facing |
| [#2277](https://github.com/TangleML/tangle-ui/pull/2277) | chore: Annotation Audit | Not user-facing (internal refactor) |

## Proposed documentation changes

- [ ] `docs/user-guide/studio-app-ui-overview.mdx` — Added a bullet to the **All Runs** section describing the new run-origin icon column (window / bot / question-mark) with hover tooltip.
- [ ] `docs/user-guide/studio-app-ui-overview.mdx` — Added a bullet to **Pipeline Run details (no task selected)** describing the run-origin icon next to the **Run Info** heading.

## Reviewer checklist

- [ ] Verified each doc change reflects actual feature behavior
- [ ] Checked for any hallucinated or inaccurate descriptions
- [ ] Confirmed all internal links resolve to real pages
- [ ] Confirmed all images/screenshots exist and are correctly referenced (no broken markdown image tags)
- [ ] Confirmed external URLs are correct and not invented
- [ ] Reviewed any new pages for correct frontmatter/metadata
- [ ] Confirmed any new pages are correctly registered in `sidebars.ts` and appear in the right category
