### PR TITLE
docs: automated update - 2026-W23

### DIFF
--- a/docs/user-guide/learning-hub.mdx
+++ b/docs/user-guide/learning-hub.mdx
@@ -1,0 +1,36 @@
+---
+id: learning-hub
+title: Learning Hub
+description: Find guides, FAQs, ready-made example pipelines, and tips for getting the most out of TangleML — all from inside the app.
+---
+
+# Learning Hub
+
+The **Learning Hub** is an in-app starting point for learning TangleML. It collects documentation links, answers to common questions, ready-made example pipelines you can import in one click, and a library of tips — so you can get unstuck without leaving the app.
+
+Open it from the **Learning Hub** entry in the dashboard sidebar.
+
+## Home
+
+The Learning Hub home page brings the most useful resources together in one view:
+
+- **Docs search** — a search box that opens matching results on the TangleML documentation site in a new tab.
+- **Quick links** — shortcuts to key documentation pages, including Getting started, Components, Pipelines, Secrets & auth, Running pipelines, and the Schema reference, plus a link to the full docs.
+- **Tip of the day** — a single rotating tip drawn from the tips library. The tip changes each day. Use **Browse all tips** to jump to the full [Tips & Tricks](#tips--tricks) library.
+- **Featured examples** — a selection of example pipelines you can import and run (see [Example pipelines](#example-pipelines)).
+- **Frequently asked** — an expandable list of common questions and answers. Click a question to reveal its answer.
+- **Need more help?** — links to ask the community in GitHub Discussions or report a bug.
+
+## Example pipelines
+
+The **Example Pipelines** page presents a grid of ready-made pipelines that you can use to learn by example.
+
+Click any pipeline card to import it. TangleML downloads the pipeline definition, creates it as a new draft pipeline, and opens it in the editor so you can inspect, run, or modify it. While a pipeline is importing, its card shows a loading state; if an import fails, an error message explains what went wrong.
+
+Imported pipelines are saved as local draft pipelines in your browser, the same as any pipeline you create yourself. For more on how drafts are stored, see [Pipelines Persistence](/docs/getting-started/pipelines-persistence).
+
+## Tips & Tricks
+
+The **Tips & Tricks** page is a browsable library of short tips covering keyboard shortcuts, features, and best practices. Tips are grouped into categories so you can scan for the area you're interested in.
+
+The same tips power the **Tip of the day** shown on the Learning Hub home page and in the dashboard sidebar.

--- a/docs/user-guide/studio-app-ui-overview.mdx
+++ b/docs/user-guide/studio-app-ui-overview.mdx
@@ -25,8 +25,9 @@ The dashboard sidebar contains the following entries:
 - **Components** — a searchable browser for User Components, the Standard Library, and Published Components.
 - **Favorites** — every pipeline and run you've starred, in a single grid with search and pagination.
 - **Recently Viewed** — the pipelines and runs you've most recently opened.
+- **Learning Hub** — guides, FAQs, ready-made example pipelines, and tips for getting the most out of TangleML. See [Learning Hub](/docs/user-guide/learning-hub).
 
-The bottom of the sidebar provides quick links to the documentation, the Settings page, and the application footer (About, Give feedback, Privacy policy, version).
+The bottom of the sidebar provides quick links to the documentation, the Settings page, and the application footer (About, Give feedback, Privacy policy, version). A rotating **Tip of the day** also appears near the bottom of the sidebar.
 
 ### My Dashboard
 
@@ -62,7 +63,7 @@ The **All Runs** view displays a comprehensive list of all pipeline runs on your
 The runs list includes a filter bar with the following controls:
 
 - **Name search**: Filter runs by pipeline name. Partial matches are supported.
-- **Created by**: Filter to show only runs created by a specific user.
+- **Created by**: Filter to show only runs created by a specific user. You can also click a user's name in any run row to instantly filter the list to that user.
 - **Date range**: Narrow results by creation date using start and end date pickers.
 - **Annotation filters**: Add key/value annotation predicates to filter runs by custom metadata attached at submission time.
 - **Active filter chips**: Active filters appear as removable chips below the filter controls. Click **Clear all** to reset.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -28,6 +28,7 @@ const sidebars: SidebarsConfig = {
         'getting-started/first-pipeline',
         'getting-started/core-concepts-and-terminology',
         'user-guide/studio-app-ui-overview',
+        'user-guide/learning-hub',
         'getting-started/pipelines-persistence',
         'component-development/adding-components',
         'user-guide/hugging-face-deployment',


### PR DESCRIPTION
## Automated documentation update — 2026-W23

> ⚠️ **This is an automated draft PR.** It was generated by the `/docs-update` skill from merged `tangle-ui` PRs and **requires human review before merging.**

### Source PRs (GA, user-facing)

| PR | Title |
| --- | --- |
| #2281 | feat: Learning Hub Dashboard |
| #2282 | feat: Learning Hub Documentation & FAQ |
| #2283 | feat: Learning Hub Example Pipelines |
| #2291 | feat: Learning Hub Tip Browser |
| #2292 | feat: Learning Hub Tip of the Day |
| #2341 | feat: Learning Hub - Milestone 1 |
| #2382 | feat: move tip of the day banner to sidebar |
| #2342 | feat: Search Run List by User via Click |

Beta features (AI Assistant, Components V2, V2 Editor fixes) were detected behind beta flags and intentionally **not** documented. Internal/embedder changes (Pre-Submit Hooks, nested-YAML depth limit) were screened out as not user-facing.

### Proposed doc changes

- [ ] **New page** `docs/user-guide/learning-hub.mdx` — documents the new in-app Learning Hub (`/learn`): docs search, quick links, Tip of the Day, importable example pipelines, FAQ, and help links.
- [ ] **Update** `docs/user-guide/studio-app-ui-overview.mdx` — adds Learning Hub to the dashboard sidebar-navigation list, notes the rotating Tip of the Day in the sidebar (#2382), and documents the click-a-username shortcut to filter the All Runs list (#2342).
- [ ] **Sidebar** `sidebars.ts` — registers `user-guide/learning-hub` under the "Getting Started" category, after the UI guide.

### Reviewer checklist

- [ ] Verified each doc change reflects actual feature behavior
- [ ] Checked for any hallucinated or inaccurate descriptions
- [ ] Confirmed all internal links resolve to real pages
- [ ] Confirmed all images/screenshots exist and are correctly referenced (no broken markdown image tags)
- [ ] Confirmed external URLs are correct and not invented
- [ ] Reviewed any new pages for correct frontmatter/metadata
- [ ] Confirmed any new pages are correctly registered in `sidebars.ts` and appear in the right category
