### PR TITLE
docs: automated update - 2026-W28

### DIFF
--- a/docs/user-guide/studio-app-ui-overview.mdx
+++ b/docs/user-guide/studio-app-ui-overview.mdx
@@ -154,6 +154,8 @@ The left panel organizes pipeline management and component access.
       - Machine learning frameworks (PyTorch, XGBoost, TensorFlow, TFX)
       - Common operations and transformations
 
+    Each component in the list shows a provenance subtitle beneath its name so you can tell at a glance where it came from: **Published by _{author}_** for components published to the connected backend, or the component's content **Digest** when it has no publisher.
+
     :::tip
     Each component has an info icon (ⓘ) that opens a detailed dialog with three tabs:
 


### PR DESCRIPTION
## Automated documentation update — 2026-W28

> **This is an automated draft PR and requires human review before merging.**
> Content was generated from merged `TangleML/tangle-ui` PRs. Verify every change against actual feature behavior before marking ready.

### Source PRs reviewed

| PR | Title | Outcome |
| --- | --- | --- |
| #2489 | Reformat union types to single-line and add format:check script | Not user-facing (tooling/formatting) |
| #2470 | Add source filter bar to editor component search | Beta — skipped (`component-search-v2`) |
| #2469 | Add source to component search v1 and v2 | Documented (GA portion only) |
| #2468 | Add editor component search loading skeleton | Beta — skipped (skeleton is `component-search-v2`) |
| #2467 | Reduce lexical search result limit and field weights | Not user-facing (beta search tuning) |
| #2463 | fix: disable upgraded components lookup in search results | Beta — skipped (`component-search-v2` results only) |
| #2441 | Add analytics tracking and thumbs feedback to AI sidekick (V2 editor) | Beta — skipped (`ai-assistant`) |

Most changes this week were confined to the beta component search (`component-search-v2`) and AI assistant (`ai-assistant`) features and were intentionally excluded. Dependency and chore PRs were filtered out by label.

### Proposed documentation changes

- [ ] **`docs/user-guide/studio-app-ui-overview.mdx`** (Editor → Left panel → Components): note that each component in the sidebar list now shows a provenance subtitle — "Published by _{author}_" for backend-published components, or the component's content "Digest" when it has no publisher. This is ungated GA behavior that surfaces from PR #2469 (and the publisher subtitle introduced in #2468), verified to render with beta flags off.

### Reviewer checklist

- [ ] Verified each doc change reflects actual feature behavior
- [ ] Checked for any hallucinated or inaccurate descriptions
- [ ] Confirmed all internal links resolve to real pages
- [ ] Confirmed all images/screenshots exist and are correctly referenced (no broken markdown image tags)
- [ ] Confirmed external URLs are correct and not invented
- [ ] Reviewed any new pages for correct frontmatter/metadata
- [ ] Confirmed any new pages are correctly registered in `sidebars.ts` and appear in the right category
