### PR TITLE
docs: automated update - 2026-W29

### DIFF
--- a/docs/user-guide/studio-app-ui-overview.mdx
+++ b/docs/user-guide/studio-app-ui-overview.mdx
@@ -465,7 +465,7 @@ Configure the connection to your TangleML backend instance:
 
 Adjust personal preferences that apply to your browser session:
 
-- Theme and display options
+- **Appearance**: Choose how Tangle looks using the **Light**, **Dark**, and **System** options. **System** follows your device's operating-system setting and switches automatically when it changes. Your selection is remembered in the browser.
 - Editor behaviour settings
 
 ### Beta Features


### PR DESCRIPTION
## Automated documentation update — 2026-W29

> ⚠️ **This is an automated draft PR.** It was generated by the `/docs-update` skill from merged `tangle-ui` PRs. It requires human review before merging.

### Source PRs (GA, user-facing)

| PR | Title |
| --- | --- |
| #2499 | feat: dark mode |
| #2504 | feat: adjust dark mode colours |

Dark mode is not gated behind a beta flag, so it is documented as generally available. The remaining ~26 merged PRs this week were either dependency bumps, internal refactors (design-token migration, EmptyState primitive, test-infra), test-only changes, or user-facing changes confined to beta surfaces (the V2 editor / run view, AI assistant, subgraphs, and the redesigned dashboard / component search), and were skipped.

### Proposed doc changes

- [ ] `docs/user-guide/studio-app-ui-overview.mdx` — Expanded the **Settings → Preferences** section to document the new **Appearance** control (Light / Dark / System theme).

### Reviewer checklist

- [ ] Verified each doc change reflects actual feature behavior
- [ ] Checked for any hallucinated or inaccurate descriptions
- [ ] Confirmed all internal links resolve to real pages
- [ ] Confirmed all images/screenshots exist and are correctly referenced (no broken markdown image tags)
- [ ] Confirmed external URLs are correct and not invented
- [ ] Reviewed any new pages for correct frontmatter/metadata
- [ ] Confirmed any new pages are correctly registered in `sidebars.ts` and appear in the right category
