### PR TITLE
docs: automated update - 2026-W30

### DIFF
--- a/docs/user-guide/studio-app-ui-overview.mdx
+++ b/docs/user-guide/studio-app-ui-overview.mdx
@@ -24,7 +24,7 @@ The dashboard sidebar contains the following entries:
 - **All Runs** — every pipeline run on your TangleML instance, with a filter bar for narrowing results.
 - **Components** — a searchable browser for User Components, the Standard Library, and Published Components.
 - **Favorites** — every pipeline and run you've starred, in a single grid with search and pagination.
-- **Recently Viewed** — the pipelines and runs you've most recently opened.
+- **Recently Viewed** — the pipelines, runs, components, and guided tours you've most recently opened.
 - **Learning Hub** — guides, FAQs, ready-made example pipelines, and tips for getting the most out of TangleML. See [Learning Hub](/docs/user-guide/learning-hub).
 
 The bottom of the sidebar provides quick links to the documentation, the Settings page, and the application footer (About, Give feedback, Privacy policy, version). A rotating **Tip of the day** also appears near the bottom of the sidebar.
@@ -34,7 +34,7 @@ The bottom of the sidebar provides quick links to the documentation, the Setting
 The **My Dashboard** view is the landing page when you visit the dashboard. It surfaces the things you're most likely to want to come back to:
 
 - **Favorites** — up to five most recently starred pipelines or runs. Hover a row to reveal an inline **X** button that removes the item from favorites without leaving the page.
-- **Recently Viewed** — up to five most recently opened pipelines or runs, with a relative timestamp showing when you last viewed each one.
+- **Recently Viewed** — up to five most recently opened items — pipelines, runs, components, or guided tours — with a relative timestamp showing when you last viewed each one.
 - **Recently Used Components** — up to five most recently opened components from the Components view.
 - **My Runs** — a compact list of up to ten runs you created, ordered by most recent first.
 
@@ -89,7 +89,9 @@ The **Favorites** view shows every pipeline and run you've starred as a card gri
 
 ### Recently Viewed
 
-The **Recently Viewed** view lists the pipelines and runs you've most recently opened, as a card grid with relative timestamps. Items are paginated 20 per page. Components are tracked separately and surface in **Recently Used Components** on My Dashboard, not in this list.
+The **Recently Viewed** view lists the items you've most recently opened — pipelines, runs, components, and guided tours — as a card grid with relative timestamps. Each card shows a coloured type pill identifying what the item is. Items are paginated 20 per page. Clicking a card takes you back to the item: pipelines open in the editor, runs open in the Pipeline Run view, components open in the Components browser with that component selected, and tours open the guided tour.
+
+**Recently Used Components** on My Dashboard is a separate list. It tracks components you've *used* in a pipeline, as distinct from components you've *viewed* in the Components browser — so a component can appear in both lists for different reasons.
 
 ## Editor
 


### PR DESCRIPTION
## Automated documentation update — 2026-W30

> **This is an automated draft PR and requires human review before merging.**
> It was generated by analysing merged `TangleML/tangle-ui` PRs from the past week
> (since 2026-07-14) and updating the docs to reflect GA, user-facing changes only.

### Source PRs that triggered changes

| PR | Title |
| --- | --- |
| #2496 | Add Tours and Components to Recently Viewed |

### Proposed documentation changes

- [ ] **`docs/user-guide/studio-app-ui-overview.mdx`** — Update the "Recently Viewed" descriptions (sidebar entry, My Dashboard preview, and the Recently Viewed view section) to reflect that Recently Viewed now tracks pipelines, runs, components, and guided tours, and to clarify how it differs from "Recently Used Components".

### Notes on what was intentionally excluded

- **Dark mode** (#2499) and its colour refinement (#2504): the "Appearance" (Light / Dark / System) setting is already documented accurately under Settings → Preferences, so no change was needed.
- **Remote troubleshoot action** (#2455, #2460): renders nothing unless a deployment injects `window.__TANGLE_EXECUTION_ACTION__` and is hidden on localhost — an operator/deployment integration that is invisible in default deployments, and already documented in-repo at `docs/remote-troubleshoot-action.md`. Not surfaced in the public user docs.
- **V2 editor / run view / window management** (numerous PRs) and **run version toggle** (#2516): gated behind the `v2_editor` beta flag — skipped until the feature graduates.

### Reviewer checklist

- [ ] Verified each doc change reflects actual feature behavior
- [ ] Checked for any hallucinated or inaccurate descriptions
- [ ] Confirmed all internal links resolve to real pages
- [ ] Confirmed all images/screenshots exist and are correctly referenced (no broken markdown image tags)
- [ ] Confirmed external URLs are correct and not invented
- [ ] Reviewed any new pages for correct frontmatter/metadata
- [ ] Confirmed any new pages are correctly registered in `sidebars.ts` and appear in the right category
